### PR TITLE
Fix optional subaccounts validation error when not specified.

### DIFF
--- a/src/validations/initialize.validation.ts
+++ b/src/validations/initialize.validation.ts
@@ -34,7 +34,7 @@ export const validateInitializeOptions = async (
         split_type: yup.string().optional(),
         transaction_charge: yup.string().optional(),
       })
-      .optional(),
+      .optional().default(undefined),
   });
 
   return await schema.validate(initializeOptions);


### PR DESCRIPTION
The yup.js validation will throw an error `subaccounts.id is required` even though the entire object is optional. This is fixed by specifying the default value of the `subaccounts` object as per this [comment](https://github.com/jquense/yup/issues/772#issuecomment-743270211).